### PR TITLE
Task `runValue` for 0.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,7 @@ scalacOptions ++= Seq(
 
 libraryDependencies ++= Seq(
   "org.scalaz" %% "scalaz-core" % "7.1.11",
+  "org.scalaz" %% "scalaz-concurrent" % "7.1.11",
   "org.scalatest" %% "scalatest" % "3.0.0"
 )
 

--- a/src/main/scala/TaskValues.scala
+++ b/src/main/scala/TaskValues.scala
@@ -1,0 +1,72 @@
+package org.typelevel.scalatest
+
+import scalaz.concurrent.Task
+import org.scalactic.source
+import org.scalatest.exceptions.{ StackDepthException, TestFailedException }
+
+import scalaz.{ -\/, \/- }
+
+trait TaskValues {
+  import scala.language.implicitConversions
+
+  /**
+   * Implicit conversion that adds a `runValue` method to `scalaz.concurrent.Task`
+   *
+   * @param task the `scalaz.concurrent.Task` on which to add the `runValue` method
+   */
+  implicit def convertTaskToTaskable[A](task: Task[A])(implicit pos: source.Position) = new Taskable(task, pos)
+
+  // TODO: Fix me as a proper repl session example
+  /**
+   * Container class for matching success
+   * type stuff in `scalaz.concurrent.Task` containers,
+   * similar to `org.scalatest.OptionValues.Valuable`
+   *
+   * Meant to allow you to make statements like:
+   *
+   * <pre class="stREPL">
+   *   task.runValue should be &gt; 15
+   * </pre>
+   *
+   * Where it only matches if the task didn't fail and the result is `\/-(9)`
+   *
+   * Otherwise your test will fail, indicating that it was left instead of right
+   *
+   * @param task A `scalaz.concurrent.Task` object to try converting to a `Taskable`
+   *
+   * @see org.scalatest.OptionValues.Valuable
+   */
+  class Taskable[A](task: Task[A], pos: source.Position) {
+    def runValue: A = {
+      task.attemptRun match {
+        case \/-(right) =>
+          right
+        case -\/(left) =>
+          throw new TestFailedException((_: StackDepthException) => Some(s"Task failed: Resulting $left is -\\/, expected \\/-."), None, pos)
+      }
+    }
+  }
+}
+
+// TODO: Fix me as a proper repl session example
+/**
+ *
+ * Companion object for easy importing – rather than mixing in – to allow `TaskValues` operations.
+ *
+ * This will permit you to invoke a `runValue` method on an instance of a `scalaz.concurrent.Task`,
+ * which attempts the Task and then attempts to return the right of the resulting disjunction.
+ *
+ *
+ * Meant to allow you to make statements like:
+ *
+ * <pre class="stREPL">
+ *   task.runValue should be &gt; 15
+ * </pre>
+ *
+ * Where it only matches if the task didn't fail and the result is `\/-(9)`
+ *
+ * Otherwise your test will fail, indicating that it was left instead of right.
+ *
+ * @see org.scalatest.OptionValues.Valuable
+ */
+object TaskValues extends TaskValues

--- a/src/main/scala/TaskValues.scala
+++ b/src/main/scala/TaskValues.scala
@@ -45,6 +45,15 @@ trait TaskValues {
           throw new TestFailedException((_: StackDepthException) => Some(s"Task failed: Resulting $left is -\\/, expected \\/-."), None, pos)
       }
     }
+
+    def failValue: Throwable = {
+      task.attemptRun match {
+        case \/-(right) =>
+          throw new TestFailedException((_: StackDepthException) => Some(s"Task failed: Resulting $right is \\/-, expected -\\/."), None, pos)
+        case -\/(left) =>
+          left
+      }
+    }
   }
 }
 

--- a/src/test/scala/TaskValuesSpec.scala
+++ b/src/test/scala/TaskValuesSpec.scala
@@ -23,5 +23,23 @@ class TaskValuesSpec extends TestBase {
       caught.failedCodeFileName.value should be("TaskValuesSpec.scala")
     }
   }
+
+  "failValue on Task" should {
+    "return the value inside a Task if the resulting disjunction is -\\/ (left)" in {
+      val e = new Exception(thisTobacconist)
+      val r: Task[String] = Task.fail(e)
+      r.failValue shouldBe e
+    }
+
+    "throw TestFailedException if the Task succeeded" in {
+      val r: Task[String] = Task.delay(thisRecord)
+      val caught =
+        intercept[TestFailedException] {
+          r.failValue should ===(thisRecord)
+        }
+      caught.failedCodeLineNumber.value should equal(thisLineNumber - 2)
+      caught.failedCodeFileName.value should be("TaskValuesSpec.scala")
+    }
+  }
 }
 

--- a/src/test/scala/TaskValuesSpec.scala
+++ b/src/test/scala/TaskValuesSpec.scala
@@ -1,0 +1,27 @@
+package org.typelevel.scalatest
+
+import org.scalatest.exceptions.TestFailedException
+
+import scalaz.concurrent.Task
+
+class TaskValuesSpec extends TestBase {
+  import TaskValues._
+
+  "runValue on Task" should {
+    "return the value inside a Task if the resulting disjunction is \\/- (right)" in {
+      val r: Task[String] = Task.delay(thisRecord)
+      r.runValue should ===(thisRecord)
+    }
+
+    "throw TestFailedException if the Task failed" in {
+      val r: Task[String] = Task.fail(new Exception(thisTobacconist))
+      val caught =
+        intercept[TestFailedException] {
+          r.runValue should ===(thisRecord)
+        }
+      caught.failedCodeLineNumber.value should equal(thisLineNumber - 2)
+      caught.failedCodeFileName.value should be("TaskValuesSpec.scala")
+    }
+  }
+}
+


### PR DESCRIPTION
I pretty much just copied the structure of the other value objects. If you think of more values or matchers I can add them to the PR. Contributes to #21.