### PR TITLE
Add Task `syncValue` for #21

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,7 @@ scalacOptions ++= Seq(
 
 libraryDependencies ++= Seq(
   "org.scalaz" %% "scalaz-core" % "7.2.7",
+  "org.scalaz" %% "scalaz-concurrent" % "7.2.7",
   "org.scalatest" %% "scalatest" % "3.0.0"
 )
 

--- a/src/main/scala/TaskValues.scala
+++ b/src/main/scala/TaskValues.scala
@@ -1,0 +1,72 @@
+package org.typelevel.scalatest
+
+import scalaz.concurrent.Task
+import org.scalactic.source
+import org.scalatest.exceptions.{ StackDepthException, TestFailedException }
+
+import scalaz.{ -\/, \/- }
+
+trait TaskValues {
+  import scala.language.implicitConversions
+
+  /**
+   * Implicit conversion that adds a `syncValue` method to `scalaz.concurrent.Task`
+   *
+   * @param task the `scalaz.concurrent.Task` on which to add the `syncValue` method
+   */
+  implicit def convertTaskToTaskable[A](task: Task[A])(implicit pos: source.Position) = new Taskable(task, pos)
+
+  // TODO: Fix me as a proper repl session example
+  /**
+   * Container class for matching success
+   * type stuff in `scalaz.concurrent.Task` containers,
+   * similar to `org.scalatest.OptionValues.Valuable`
+   *
+   * Meant to allow you to make statements like:
+   *
+   * <pre class="stREPL">
+   *   task.syncValue should be &gt; 15
+   * </pre>
+   *
+   * Where it only matches if the task didn't fail and the result is `\/-(9)`
+   *
+   * Otherwise your test will fail, indicating that it was left instead of right
+   *
+   * @param task A `scalaz.concurrent.Task` object to try converting to a `Taskable`
+   *
+   * @see org.scalatest.OptionValues.Valuable
+   */
+  class Taskable[A](task: Task[A], pos: source.Position) {
+    def syncValue: A = {
+      task.unsafePerformSyncAttempt match {
+        case \/-(right) =>
+          right
+        case -\/(left) =>
+          throw new TestFailedException((_: StackDepthException) => Some(s"Task failed: Resulting $left is -\\/, expected \\/-."), None, pos)
+      }
+    }
+  }
+}
+
+// TODO: Fix me as a proper repl session example
+/**
+ *
+ * Companion object for easy importing – rather than mixing in – to allow `TaskValues` operations.
+ *
+ * This will permit you to invoke a `syncValue` method on an instance of a `scalaz.concurrent.Task`,
+ * which attempts the Task and then attempts to return the right of the resulting disjunction.
+ *
+ *
+ * Meant to allow you to make statements like:
+ *
+ * <pre class="stREPL">
+ *   task.syncValue should be &gt; 15
+ * </pre>
+ *
+ * Where it only matches if the task didn't fail and the result is `\/-(9)`
+ *
+ * Otherwise your test will fail, indicating that it was left instead of right.
+ *
+ * @see org.scalatest.OptionValues.Valuable
+ */
+object TaskValues extends TaskValues

--- a/src/main/scala/TaskValues.scala
+++ b/src/main/scala/TaskValues.scala
@@ -45,6 +45,15 @@ trait TaskValues {
           throw new TestFailedException((_: StackDepthException) => Some(s"Task failed: Resulting $left is -\\/, expected \\/-."), None, pos)
       }
     }
+
+    def failValue: Throwable = {
+      task.unsafePerformSyncAttempt match {
+        case \/-(right) =>
+          throw new TestFailedException((_: StackDepthException) => Some(s"Task failed: Resulting $right is \\/-, expected -\\/."), None, pos)
+        case -\/(left) =>
+          left
+      }
+    }
   }
 }
 

--- a/src/test/scala/TaskValuesSpec.scala
+++ b/src/test/scala/TaskValuesSpec.scala
@@ -1,0 +1,26 @@
+package org.typelevel.scalatest
+
+import org.scalatest.exceptions.TestFailedException
+
+import scalaz.concurrent.Task
+
+class TaskValuesSpec extends TestBase {
+  import TaskValues._
+
+  "runValue on Task" should {
+    "return the value inside a Task if the resulting disjunction is \\/- (right)" in {
+      val r: Task[String] = Task.delay(thisRecord)
+      r.syncValue should ===(thisRecord)
+    }
+
+    "throw TestFailedException if the Task failed" in {
+      val r: Task[String] = Task.fail(new Exception(thisTobacconist))
+      val caught =
+        intercept[TestFailedException] {
+          r.syncValue should ===(thisRecord)
+        }
+      caught.failedCodeLineNumber.value should equal(thisLineNumber - 2)
+      caught.failedCodeFileName.value should be("TaskValuesSpec.scala")
+    }
+  }
+}

--- a/src/test/scala/TaskValuesSpec.scala
+++ b/src/test/scala/TaskValuesSpec.scala
@@ -7,7 +7,7 @@ import scalaz.concurrent.Task
 class TaskValuesSpec extends TestBase {
   import TaskValues._
 
-  "runValue on Task" should {
+  "syncValue on Task" should {
     "return the value inside a Task if the resulting disjunction is \\/- (right)" in {
       val r: Task[String] = Task.delay(thisRecord)
       r.syncValue should ===(thisRecord)
@@ -18,6 +18,24 @@ class TaskValuesSpec extends TestBase {
       val caught =
         intercept[TestFailedException] {
           r.syncValue should ===(thisRecord)
+        }
+      caught.failedCodeLineNumber.value should equal(thisLineNumber - 2)
+      caught.failedCodeFileName.value should be("TaskValuesSpec.scala")
+    }
+  }
+
+  "failValue on Task" should {
+    "return the value inside a Task if the resulting disjunction is -\\/ (left)" in {
+      val e = new Exception(thisTobacconist)
+      val r: Task[String] = Task.fail(e)
+      r.failValue shouldBe e
+    }
+
+    "throw TestFailedException if the Task succeeded" in {
+      val r: Task[String] = Task.delay(thisRecord)
+      val caught =
+        intercept[TestFailedException] {
+          r.failValue should ===(thisRecord)
         }
       caught.failedCodeLineNumber.value should equal(thisLineNumber - 2)
       caught.failedCodeFileName.value should be("TaskValuesSpec.scala")


### PR DESCRIPTION
I pretty much just copied the structure of the other value objects. If you think of more values or matchers I can add them to the PR. Contributes to #21.
